### PR TITLE
release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ### ~
 
+### v0.1.1 (2023-08-05)
+* adds support for "text size" and "high contrast" app themes.
+* updates targetSdkVersion to 33; updates androidx libraries.
+* updates SuntimesAddon dependency to v0.4.0.
+
 ### v0.1.0 (2023-02-01)
 * dismiss Suntimes Alarms using an NFC tag; implements `suntimes.action.DISMISS_CHALLENGE`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### v0.1.1 (2023-08-05)
 * adds support for "text size" and "high contrast" app themes.
-* updates targetSdkVersion to 33; updates androidx libraries.
-* updates SuntimesAddon dependency to v0.4.0.
+* updates targetSdkVersion (31 -> 33); updates androidx libraries.
+* updates SuntimesAddon dependency (v0.4.0).
 
 ### v0.1.0 (2023-02-01)
 * dismiss Suntimes Alarms using an NFC tag; implements `suntimes.action.DISMISS_CHALLENGE`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         minSdkVersion 16
         //noinspection OldTargetApi
         targetSdkVersion 33
-        versionCode 1
-        versionName "0.1.0"
+        versionCode 2
+        versionName "0.1.1"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/fastlane/metadata/android/en-US/changelogs/2.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2.txt
@@ -1,0 +1,1 @@
+- adds support for "text size" and "high contrast" app themes.


### PR DESCRIPTION
* adds support for "text size" and "high contrast" app themes.
* updates targetSdkVersion (31 -> 33); updates androidx libraries.
* updates SuntimesAddon dependency (v0.4.0).